### PR TITLE
chore: Update Go version and GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,7 @@ jobs:
 
             - name: Copy Binary and Makefile to VPS
               if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'test')) }}
-              uses: appleboy/scp-action@v1.0.0
+              uses: appleboy/scp-action@v1
               with:
                   host: ${{ secrets.VPS_HOST }}
                   username: ${{ secrets.VPS_USERNAME }}
@@ -77,7 +77,7 @@ jobs:
 
             - name: SSH and Restart Services
               if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'test')) }}
-              uses: appleboy/ssh-action@v1.0.0
+              uses: appleboy/ssh-action@v1
               with:
                   host: ${{ secrets.VPS_HOST }}
                   username: ${{ secrets.VPS_USERNAME }}

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ build-local: clean-extractor
 	printf "\nBuilding for the local machine: ($$(go env GOOS)/$$(go env GOARCH))...\n"
 	cp $(ROOT_PATH)/.env $(ROOT_PATH)/bin/.env
 	docker build \
-		--build-arg BUILDER_IMAGE=golang:1.24-bookworm \
+		--build-arg BUILDER_IMAGE=golang:1.25.3-bookworm \
 		--build-arg BINARY_NAME=$(BINARY_NAME) \
 		--build-arg INFRA_USER=$(DOCKER_INFRA_USER) \
 		--build-arg INFRA_GROUP=$(DOCKER_INFRA_GROUP) \

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ build-local: clean-extractor
 	printf "\nBuilding for the local machine: ($$(go env GOOS)/$$(go env GOARCH))...\n"
 	cp $(ROOT_PATH)/.env $(ROOT_PATH)/bin/.env
 	docker build \
-		--build-arg BUILDER_IMAGE=golang:1.25.3-bookworm \
+		--build-arg BUILDER_IMAGE=golang:1.25.4-bookworm \
 		--build-arg BINARY_NAME=$(BINARY_NAME) \
 		--build-arg INFRA_USER=$(DOCKER_INFRA_USER) \
 		--build-arg INFRA_GROUP=$(DOCKER_INFRA_GROUP) \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25.3
 
 # --- The builder image can be overridden. This allows to swap images for
 #     local compilations defaults to the lean Alpine image for production.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ ARG GO_VERSION=1.25.3
 ARG BUILDER_IMAGE=golang:${GO_VERSION}-alpine
 
 # The final image base.
-ARG FINAL_IMAGE=alpine:latest
+ARG FINAL_IMAGE=alpine:3.22
 
 # Build-time variables for your application.
 ARG INFRA_VERSION="0.0.0.0"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.25.3
+ARG GO_VERSION=1.25.4
 
 # --- The builder image can be overridden. This allows to swap images for
 #     local compilations defaults to the lean Alpine image for production.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oullin/infra
 
-go 1.25.3
+go 1.25.4
 
 require (
 	github.com/go-playground/validator/v10 v10.26.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oullin/infra
 
-go 1.24
+go 1.25.3
 
 require (
 	github.com/go-playground/validator/v10 v10.26.0


### PR DESCRIPTION
- Update go.mod to specify Go 1.25.3
- Update Dockerfile to use Go 1.25.3 in builder image
- GitHub Actions will automatically use updated version via Docker build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow actions to newer versions for improved reliability and security.
  * Upgraded Go toolchain to 1.25.4 across build configuration, container images, and development environment.
  * Updated base runtime image to a newer Alpine release and adjusted build targets to keep build/runtime images consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->